### PR TITLE
Added Spacing Option to Square style

### DIFF
--- a/src/Avity.php
+++ b/src/Avity.php
@@ -132,6 +132,16 @@ class Avity
         return $this;
     }
 
+    /**
+     * Returns the style object
+     *
+     * @return Style The style object.
+     */
+    public function style()
+    {
+        return $this->style;
+    }
+
     public function generate()
     {
       	// returns an

--- a/src/Styles/Square.php
+++ b/src/Styles/Square.php
@@ -7,6 +7,7 @@ use Hedronium\Avity\Style;
 */
 class Square extends Style
 {
+    public $spacing = 0;
 
     public function draw()
     {
@@ -39,6 +40,9 @@ class Square extends Style
           $block_width = $working_width/$columns;
           $block_height = $working_height/$rows;
 
+          // Calculate Spacing
+          $spacing = $this->spacing/2;
+
           // Creates a color to be used to draw the squares
           $color = imagecolorallocate($canvas, 70, 70, 70);
 
@@ -54,12 +58,12 @@ class Square extends Style
                        imagefilledrectangle(
                            $canvas,
                            // Caculates the co-ordinate (x, y) of the top-left corner of the square.
-                           ($block_width*$x)+$start_x,
-                           ($block_height*$y)+$start_x,
+                           ($block_width*$x)+$start_x+$spacing,
+                           ($block_height*$y)+$start_x+$spacing,
 
                          	// Caculates the co-ordinate (x, y) of the bottom-right corner of the square.
-                           ($block_width*($x+1))+$start_x,
-                           ($block_height*($y+1))+$start_y,
+                           ($block_width*($x+1))+$start_x-$spacing,
+                           ($block_height*($y+1))+$start_y-$spacing,
 
                            $color
                        );


### PR DESCRIPTION
You can now add spacing to identicon blocks via `$avity->style()->spacing = 10`

eg

``` PHP
<?php
use Hedronium\Avity\Avity;

$avity = Avity::init()
->height(400)
->width(400)
->columns(6)
->rows(6)
->padding(40);

$avity->style()->spacing = 10;

$avity->generate()
->png()
->toBrowser();
```

![test](https://cloud.githubusercontent.com/assets/4700757/11337270/e8f46c4a-9215-11e5-85d6-4cd6acfefe14.png)
